### PR TITLE
improve error handling for models that fail on the first op

### DIFF
--- a/src/knossos/linear/report.clj
+++ b/src/knossos/linear/report.clj
@@ -181,7 +181,7 @@ function dbar(id) {
   (->> ops
        (map (fn [op]
               (let [i   (:index op)
-                    _   (assert i)
+                    _   (assert i (str "Expected index but got " (pr-str i) " for op " (pr-str op)))
                     inv (history/invocation pair-index op)
                     _   (assert inv (str "No invocation for op " (pr-str op)))
                     t1  (max tmin (:index inv))


### PR DESCRIPTION
Resolves "Knossos: Better error messages when users pass models that fail on the first op ..." in https://github.com/jepsen-io/jepsen/blob/master/doc/plan.md

References https://github.com/jepsen-io/jepsen/issues/168