### PR TITLE
Support histories with external indices and use to link linear.svg to timeline.html

### DIFF
--- a/report/.gitignore
+++ b/report/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/src/knossos/history.clj
+++ b/src/knossos/history.clj
@@ -252,23 +252,22 @@
 
 (defn kindex
   "Takes a history and returns a new history with internal knossos indices and a map of
-  knossos indices to external indices."
+  knossos indices to external indices. Throws IllegalArgumentException if given history
+  does not have unique indices"
   [history]
-  (let [eindices (map :index history)
-        history' (index history)
-        m (->> history'
-               (map :index)
-               (#(map vector % eindices))
-               (into {}))]
-    [history' m]))
-
-; TODO Validate external indices are unique in kindex, otherwise the mapping is not bijective
-#_(when (and (not (every? #(= -1 %) eindices))
-             (not (every? nil? eindices))
-             (not (apply distinct? eindices)))
-    (throw (IllegalArgumentException. (str "History starting with "
-                                           (first history)
-                                           " contains ops with non-unique indices"))))
+  (let [eindices (map :index history)]
+    (if (or (every? #(= -1 %) eindices)
+            (every? nil? eindices)
+            (apply distinct? eindices))
+      (let [history' (index history)
+            m (->> history'
+                   (map :index)
+                   (#(map vector % eindices))
+                   (into {}))]
+        [history' m])
+      (throw (IllegalArgumentException. (str "History starting with "
+                                             (pr-str (first history))
+                                             " contains ops with non-unique indices"))))))
 
 (defn indexed?
   "Is the given history indexed?"

--- a/src/knossos/history.clj
+++ b/src/knossos/history.clj
@@ -275,6 +275,13 @@
   (or (empty? history)
       (integer? (:index (first history)))))
 
+(defn ensure-indexed
+  "Makes sure a history is indexed when we start our analysis"
+  [history]
+  (if-not (indexed? history)
+    (index history)
+    history))
+
 (defn op-with-internal-index->op-with-external-index
   "Uses the internal index to reattach the index that an op had when it was passed in"
   [mapping op]

--- a/src/knossos/history.clj
+++ b/src/knossos/history.clj
@@ -242,7 +242,6 @@
        first
        persistent!))
 
-
 (defn index
   "Attaches an :index key to each element of the history, identifying its
   position in the history vector."
@@ -250,6 +249,24 @@
   (->> history
        (mapv (fn [i op] (assoc op :index i)) (range))
        vec))
+
+; TODO Bench this
+(defn kindex
+  "Overwrites the :index key on each op with a knossos-specific index, returning the new history
+  and a map of external indices to knossos indices. Throws IllegalArgumentException if external
+  indices are not all unique."
+  [history]
+  (let [eindices (map :index history)
+        ; FIXME
+        _ (when (and eindices (not (apply distinct? eindices)))
+            (throw (IllegalArgumentException. "History's indices are not all unique")))
+        history' (index history)
+        ; Map external indices to kindices
+        m (->> history'
+               (map :index)
+               (map vector eindices)
+               (into {}))]
+    [history' m]))
 
 (defn indexed?
   "Is the given history indexed?"

--- a/src/knossos/linear.clj
+++ b/src/knossos/linear.clj
@@ -144,7 +144,7 @@
 
       {:op    some-op
        :model model-resulting-from-applying-op}"
-  [history op configs]
+  [history op configs indices]
   (->> configs
        (map (fn [config]
               (analysis/final-paths-for-config [{:op    (:last-op config)
@@ -154,7 +154,11 @@
        (reduce set/union)
        ; And now unwrap memoization
        (map (fn [path]
-              (mapv (fn [transition] (update transition :model memo/unwrap))
+              (mapv (fn [transition]
+                      (let [m (memo/unwrap (:model transition))
+                            o (history/render-op indices (:op transition))]
+                        {:op    o
+                         :model m}))
                     path)))
        set))
 
@@ -178,7 +182,8 @@
     ; If we're handling a completion, run each configuration through a
     ; just-in-time linearization, accumulating a new set of configs.
     (op/ok? op)
-    (let [cache    (weak-cache-set/clear! cache)
+    (let [indices  (:indices @state)
+          cache    (weak-cache-set/clear! cache)
           configs' (if (< (count configs) parallel-threshold)
                      ; Singlethreaded search
                      (let [configs' (config/set-config-set)]
@@ -197,19 +202,19 @@
 
       (if (empty? configs')
         ; Out of options! Return a reduced debugging state.
-        (reduced {:valid?       false
-                  :configs      (map config/config->map configs)
-                  :final-paths  (final-paths history op configs)
-                  :previous-ok  (analysis/previous-ok history op)
-                  :last-op  (reduce (fn [op config]
-                                      (if (or (nil? op)
-                                              (< (:index op)
-                                                 (:index (:last-op config))))
-                                        (:last-op config)
-                                        op))
-                                    nil
-                                    configs)
-                  :op           op})
+        (reduced {:valid?      false
+                  :configs     (map #(config/config->map indices %) configs)
+                  :final-paths (final-paths history op configs indices)
+                  :previous-ok (history/render-op indices (analysis/previous-ok history op))
+                  :last-op     (reduce (fn [op config]
+                                     (if (or (nil? op)
+                                             (< (:index op)
+                                                (:index (:last-op config))))
+                                       (history/render-op indices (:last-op config))
+                                       op))
+                                   nil
+                                   configs)
+                  :op          (history/render-op indices op)})
         ; Otherwise, return new config set.
         configs'))
 
@@ -222,32 +227,31 @@
   (let [cache   (weak-cache-set/nbhs)
         res     (reduce (partial step history state cache)
                         configs
-                        history)]
+                        history)
+        indices (:indices @state)]
     (if (and (map? res) (= false (:valid? res)))
       ; Reduced error
       res
       {:valid?  true
-       :configs (map config/config->map res)})))
+       :configs (map #(config/config->map indices %) res)})))
 
 (defn results-for-interrupted-state
   "Computes a result map for an interrupted search."
   [history configs state]
-  (let [{:keys [cause configs op]} @state]
+  (let [{:keys [cause configs op indices]} @state]
     {:valid?       :unknown
      :cause        cause
-     :configs      (map config/config->map configs)
-     :previous-ok  (analysis/previous-ok history op)
+     :configs      (map #(config/config->map indices %) configs)
+     :previous-ok  (history/render-op indices (analysis/previous-ok history op))
      :last-op      (reduce (fn [op config]
                              (if (or (nil? op)
                                      (< (:index op)
-                                        (:index (:last-op
-                                                  config))))
-                               (:last-op config))
+                                        (:index (:last-op config))))
+                               (history/render-op indices (:last-op config)))
                              op)
                            nil
                            configs)
-     :op           op}))
-
+     :op           (history/render-op indices op)}))
 
 (defn start-analysis
   "Spawns a Search to check a history."
@@ -255,7 +259,7 @@
   (let [history (-> history
                     history/parse-ops
                     history/complete)
-        [history index-kindex] (history/kindex history)
+        [history kindex-eindex] (history/kindex history)
         memo (memo model history)
         history (:history memo)
         configs (-> (:model memo)
@@ -265,7 +269,7 @@
         state (atom {:running?     true
                      :configs      configs
                      :op           nil
-                     :index-kindex index-kindex})
+                     :indices kindex-eindex})
         results   (promise)
         worker    (Thread.
                     (fn []
@@ -295,7 +299,7 @@
                       (map config/estimated-cost)
                       (reduce +)
                       (cl-format nil "~,2e"))
-         :op    (:op state)}))
+           :op    (history/render-op kindex-eindex (:op state))}))
 
       (results [_] @results)
       (results [_ timeout timeout-val] (deref results timeout timeout-val)))))

--- a/src/knossos/linear.clj
+++ b/src/knossos/linear.clj
@@ -259,7 +259,8 @@
   [model history]
   (let [history (-> history
                     history/parse-ops
-                    history/complete)
+                    history/complete
+                    history/ensure-indexed)
         [history kindex-eindex] (history/kindex history)
         memo (memo model history)
         history (:history memo)

--- a/src/knossos/linear.clj
+++ b/src/knossos/linear.clj
@@ -208,7 +208,6 @@
                   :previous-ok (history/render-op indices (analysis/previous-ok history op))
                   :last-op     (reduce (fn [op config]
                                      (if (or (nil? op)
-                                             (nil? (:index op))
                                              (< (:index op)
                                                 (:index (:last-op config))))
                                        (history/render-op indices (:last-op config))
@@ -258,9 +257,9 @@
   "Spawns a Search to check a history."
   [model history]
   (let [history (-> history
+                    history/ensure-indexed
                     history/parse-ops
-                    history/complete
-                    history/ensure-indexed)
+                    history/complete)
         [history kindex-eindex] (history/kindex history)
         memo (memo model history)
         history (:history memo)
@@ -311,4 +310,5 @@
   linearizable. Returns a map with a :valid? bool and additional debugging
   information."
   [model history]
-  (search/run (start-analysis model history)))
+  (assoc (search/run (start-analysis model history))
+         :analysis :linear))

--- a/src/knossos/linear.clj
+++ b/src/knossos/linear.clj
@@ -254,17 +254,18 @@
   [model history]
   (let [history (-> history
                     history/parse-ops
-                    history/complete
-                    history/index)
+                    history/complete)
+        [history index-kindex] (history/kindex history)
         memo (memo model history)
         history (:history memo)
         configs (-> (:model memo)
                     (config/config history)
                     list
                     config/set-config-set)
-        state (atom {:running?  true
-                     :configs   configs
-                     :op        nil})
+        state (atom {:running?     true
+                     :configs      configs
+                     :op           nil
+                     :index-kindex index-kindex})
         results   (promise)
         worker    (Thread.
                     (fn []

--- a/src/knossos/linear.clj
+++ b/src/knossos/linear.clj
@@ -208,6 +208,7 @@
                   :previous-ok (history/render-op indices (analysis/previous-ok history op))
                   :last-op     (reduce (fn [op config]
                                      (if (or (nil? op)
+                                             (nil? (:index op))
                                              (< (:index op)
                                                 (:index (:last-op config))))
                                        (history/render-op indices (:last-op config))

--- a/src/knossos/linear.clj
+++ b/src/knossos/linear.clj
@@ -311,4 +311,4 @@
   information."
   [model history]
   (assoc (search/run (start-analysis model history))
-         :analysis :linear))
+         :analyzer :linear))

--- a/src/knossos/linear/report.clj
+++ b/src/knossos/linear/report.clj
@@ -430,7 +430,7 @@ function dbar(id) {
                                                    history/ensure-indexed
                                                    history/complete
                                                    history/with-synthetic-infos)]
-                                   (if (= :wgl (:checker analysis))
+                                   (if (= :wgl (:analyzer analysis))
                                      (history/without-failures history)
                                      history))
         [history kindex->eindex] (history/kindex history)

--- a/src/knossos/op.clj
+++ b/src/knossos/op.clj
@@ -8,6 +8,11 @@
 
 (defrecord Op [process type f value ^:int index])
 
+(defn Op->map
+  "Turns an Op back into a plain old map"
+  [^Op op]
+  (when op (into {} op)))
+
 (defn op
   "Constructs a new operation for a history."
   [process type f value]

--- a/src/knossos/wgl.clj
+++ b/src/knossos/wgl.clj
@@ -487,11 +487,12 @@
 
 (defn check
   [model history state]
-  (let [history     (->> history
-                         history/parse-ops
-                         history/complete
-                         history/with-synthetic-infos
-                         history/without-failures)
+  (let [history (->> history
+                     history/parse-ops
+                     history/complete
+                     history/with-synthetic-infos
+                     history/without-failures
+                     history/ensure-indexed)
         [history kindex-eindex] (history/kindex history)
         _ (swap! state assoc :indices kindex-eindex)
         history (->> history

--- a/src/knossos/wgl.clj
+++ b/src/knossos/wgl.clj
@@ -213,7 +213,7 @@
   external index"
   [indices op]
   (let [o (Op->map op)
-        m (history/op-with-internal-index->op-with-external-index indices o)]
+        m (history/convert-op-index indices o)]
     (if (:index m)
       m
       (dissoc m :index))))
@@ -488,11 +488,11 @@
 (defn check
   [model history state]
   (let [history (->> history
+                     history/ensure-indexed
                      history/parse-ops
                      history/complete
                      history/with-synthetic-infos
-                     history/without-failures
-                     history/ensure-indexed)
+                     history/without-failures)
         [history kindex-eindex] (history/kindex history)
         _ (swap! state assoc :indices kindex-eindex)
         history (->> history
@@ -627,4 +627,5 @@
   linearizable. Returns a map with a :valid? bool and additional debugging
   information."
   [model history]
-  (search/run (start-analysis model history)))
+  (assoc (search/run (start-analysis model history))
+         :analysis :wgl))

--- a/src/knossos/wgl.clj
+++ b/src/knossos/wgl.clj
@@ -628,4 +628,4 @@
   information."
   [model history]
   (assoc (search/run (start-analysis model history))
-         :analysis :wgl))
+         :analyzer :wgl))

--- a/src/knossos/wgl.clj
+++ b/src/knossos/wgl.clj
@@ -197,15 +197,26 @@
        (dissoc m :process :type :f :value :index :entry-id)))
 
 (defn Op->map
-  "Turns an Op back into a plain old map, stripping its index and entry ids."
+  "Turns an Op back into a plain old map, stripping its entry ids."
   [^Op op]
   (when op
     (into
       {:process (.process op)
        :type    (.type op)
        :f       (.f op)
-       :value   (.value op)}
+       :value   (.value op)
+       :index   (.index op)}
       (.m op))))
+
+(defn render-op
+  "Prepares an op to be returned by converting it to a plain old map and reassigning its
+  external index"
+  [indices op]
+  (let [o (Op->map op)
+        m (history/op-with-internal-index->op-with-external-index indices o)]
+    (if (:index m)
+      m
+      (dissoc m :index))))
 
 ; This is the datatype we use to prune our exploration of the search space. We
 ; assume the linearized BitSet is immutable, memoizing its hashing to optimize
@@ -415,7 +426,7 @@
   of operations. We take that state and apply all concurrent operations to it,
   in every possible order, ending with the final op which broke
   linearizability."
-  [history pair-index final-op configs]
+  [history pair-index final-op configs indices]
   (let [calls (concurrent-ops-at history final-op)]
     (->> configs
          (map (fn [^CacheConfig config]
@@ -435,14 +446,14 @@
          (map (fn [path]
                 (mapv (fn [transition]
                         (let [m (memo/unwrap (:model transition))
-                              o (Op->map (:op transition))]
+                              o (render-op indices (:op transition))]
                           {:op o :model m}))
                       path)))
          set)))
 
 (defn invalid-analysis
   "Constructs an analysis of an invalid terminal state."
-  [history configs]
+  [history configs state]
   (let [pair-index     (history/pair-index+ history)
         ; We failed because we ran into an OK entry. That means its invocation
         ; couldn't be linearized. What was the entry ID for that invocation?
@@ -461,15 +472,17 @@
         configs (->> configs
                      (configurations-which-linearized-up-to
                        (dec final-entry-id)))
+
+        indices (:indices @state)
         ;_     (prn :configs)
         ;_     (pprint configs)
 
         ; Now compute the final paths from the previous ok operation to the
         ; nonlinearizable one
-        final-paths (final-paths history pair-index final-ok configs)]
+        final-paths (final-paths history pair-index final-ok configs indices)]
     {:valid?      false
-     :op          (Op->map final-ok)
-     :previous-ok (Op->map previous-ok)
+     :op          (render-op indices final-ok)
+     :previous-ok (render-op indices previous-ok)
      :final-paths final-paths}))
 
 (defn check
@@ -478,10 +491,12 @@
                          history/parse-ops
                          history/complete
                          history/with-synthetic-infos
-                         history/without-failures
-                         history/index
-                         with-entry-ids
-                         (mapv map->Op))
+                         history/without-failures)
+        [history kindex-eindex] (history/kindex history)
+        _ (swap! state assoc :indices kindex-eindex)
+        history (->> history
+                     with-entry-ids
+                     (mapv map->Op))
         {:keys [model history]} (memo model history)
         ; _ (pprint history)
         n           (max (max-entry-id history) 0)
@@ -550,7 +565,7 @@
               :ok
               (if (.isEmpty calls)
                 ; We have nowhere left to backtrack to.
-                (invalid-analysis history cache)
+                (invalid-analysis history cache state)
 
                 ; Backtrack, reverting to an earlier state.
                 (let [[^INode entry s]  (.removeFirst calls)

--- a/test/knossos/history_test.clj
+++ b/test/knossos/history_test.clj
@@ -42,8 +42,8 @@
           [history m] (kindex history)
           op0  (first history)
           op1  (last  history)
-          op0' (op-with-internal-index->op-with-external-index m op0)
-          op1' (op-with-internal-index->op-with-external-index m op1)]
+          op0' (convert-op-index m op0)
+          op1' (convert-op-index m op1)]
       (is (= 0   (:index op0)))
       (is (= 3   (:index op1)))
       (is (= 5   (:index op0')))

--- a/test/knossos/linear/config_test.clj
+++ b/test/knossos/linear/config_test.clj
@@ -103,24 +103,26 @@
 (deftest config->map-test
   (let [w1 {:index 0 :process 0 :type :invoke :f :write :value 1}
         r2 {:index 1 :process 1 :type :invoke :f :read  :value 2}
+        indices {0 nil
+                 1 nil}
         h  [w1 r2]
         c  (config (register 0) h)]
     (testing "initial"
       (is (= {:model (register 0)
               :last-op nil
               :pending []}
-             (config->map c))))
+             (config->map indices c))))
 
     (testing "pending"
       (let [c (-> c (t-call w1))]
         (is (= {:model (register 0)
                 :last-op nil
-                :pending [w1]}
-               (config->map c)))))
+                :pending [{:process 0 :type :invoke :f :write :value 1}]}
+               (config->map indices c)))))
 
     (testing "linearized"
       (let [c (-> c (t-call w1) (t-lin w1))]
         (is (= {:model (register 1)
-                :last-op w1
+                :last-op {:process 0 :type :invoke :f :write :value 1}
                 :pending []}
-               (config->map c)))))))
+               (config->map indices c)))))))

--- a/test/knossos/wgl_test.clj
+++ b/test/knossos/wgl_test.clj
@@ -19,6 +19,20 @@
                      (op/ok     0 :read 0)])]
     (is (:valid? a))))
 
+(deftest preserves-indices-test
+  (let [model (register 0)
+        history [{:process 0 :type :invoke :f :write :value 1 :index 5}
+                 {:process 0 :type :ok     :f :write :value 1 :index 7}
+                 {:process 0 :type :invoke :f :read :value 2 :index 99}
+                 {:process 0 :type :ok     :f :read :value 2 :index 100}]
+        a (analysis model history)]
+    (is (not (:valid? a)))
+    (is (= 100 (get-in a [:op :index])))
+    (is (= 7   (get-in a [:previous-ok :index])))
+    (let [final-paths (-> a :final-paths vec first)]
+      (is (= 7   (-> final-paths first  :op :index)))
+      (is (= 100 (-> final-paths second :op :index))))))
+
 (deftest read-wrong-initial-value-test
   (let [model (register 0)
         history [{:process 0 :type :invoke :f :read :value 1}


### PR DESCRIPTION
Both `knossos.linear` and `knossos.wgl` render debugging output with the same ops' indices as they are passed in. I also updated linear to return plain maps, same as WGL, and added some cases from WGL to linear-test.

One change that I'm suspect of is that I needed to add a check for `:index nil` in `knossos.linear/step` so that report-test would stop `NullPointerException`ing. As far as I can tell this doesn't change the behavior for linear outside of report, so I'm puzzled as to why this is happening.
https://github.com/jepsen-io/knossos/compare/master...mkcp:support-jepsen-indices?expand=1#diff-8f4c4f892cd240e9882c1d2b666c1a35R211