### PR TITLE
analyzers: add :time-limit feature in opts map for linear, wgl, and competition

### DIFF
--- a/src/knossos/competition.clj
+++ b/src/knossos/competition.clj
@@ -5,8 +5,16 @@
                      [wgl :as wgl]]))
 
 (defn analysis
-  [model history]
-  (search/run
-    (search/competition
-      {:linear (linear/start-analysis model history)
-       :wgl    (wgl/start-analysis model history)})))
+  "Given an initial model state and a history, checks to see if the history is
+  linearizable by running both the :linaer and :wgl analyzers.
+  Returns a map with a :valid? bool and additional debugging information.
+
+  Can also take an options map:
+  {:time-limit ms} Duration to wait before returning with result :unknown"
+  ([model history]
+   (analysis model history {}))
+  ([model history opts]
+   (search/run
+     (search/competition {:linear (linear/start-analysis model history)
+                          :wgl    (wgl/start-analysis model history)})
+     opts)))

--- a/src/knossos/core.clj
+++ b/src/knossos/core.clj
@@ -16,5 +16,7 @@
 
 (defn analysis
   "Alias for competition/analysis"
-  [model history]
-  (competition/analysis model history))
+  ([model history]
+   (analysis model history {}))
+  ([model history opts]
+   (competition/analysis model history opts)))

--- a/src/knossos/linear.clj
+++ b/src/knossos/linear.clj
@@ -308,7 +308,12 @@
 (defn analysis
   "Given an initial model state and a history, checks to see if the history is
   linearizable. Returns a map with a :valid? bool and additional debugging
-  information."
-  [model history]
-  (assoc (search/run (start-analysis model history))
-         :analyzer :linear))
+  information.
+
+  Can also take an options map:
+  {:time-limit ms} Duration to wait before returning with result :unknown"
+  ([model history]
+   (analysis model history {}))
+  ([model history opts]
+   (assoc (search/run (start-analysis model history) opts)
+          :analyzer :linear)))

--- a/src/knossos/wgl.clj
+++ b/src/knossos/wgl.clj
@@ -625,7 +625,12 @@
 (defn analysis
   "Given an initial model state and a history, checks to see if the history is
   linearizable. Returns a map with a :valid? bool and additional debugging
-  information."
-  [model history]
-  (assoc (search/run (start-analysis model history))
-         :analyzer :wgl))
+  information.
+
+  Can also take an options map:
+  {:time-limit ms} Duration to wait before returning with result :unknown"
+  ([model history]
+   (analysis model history {}))
+  ([model history opts]
+   (assoc (search/run (start-analysis model history) opts)
+          :analyzer :wgl)))

--- a/test/knossos/competition_test.clj
+++ b/test/knossos/competition_test.clj
@@ -7,5 +7,37 @@
             [knossos.core-test :as ct]
             [clojure.pprint :refer [pprint]]))
 
+(deftest timeout-test
+  (testing "will timeout if limit exceeded"
+    (let [model (cas-register 0)
+          history (ct/read-history-2 "data/cas-register/good/memstress3-12.edn")
+          ;; Time limit of 1ms
+          a (analysis model history {:time-limit 1})]
+      (is (= {:valid?   :unknown
+              :cause    :timeout}
+             a))))
+
+  (testing "does not timeout when limit not exceeded"
+    (let [model (register 0)
+          history [(invoke 0 :write 1)
+                   (ok     0 :write 1)]
+          a (analysis model history {:time-limit 999999999999999})]
+      (is (not= {:valid?   :unknown
+                 :cause    :timeout}
+                a))))
+
+  (testing "does not timeout with no time-limit"
+    (let [model (register 0)
+          history [(invoke 0 :write 1)
+                   (ok     0 :write 1)]
+          a1 (analysis model history)
+          a2 (analysis model history {:time-limit nil})]
+      (is (not= {:valid?   :unknown
+                 :cause    :timeout}
+                a1))
+      (is (not= {:valid?   :unknown
+                 :cause    :timeout}
+                a2)))))
+
 (deftest ^:perf example-test
   (ct/test-examples analysis))

--- a/test/knossos/wgl_test.clj
+++ b/test/knossos/wgl_test.clj
@@ -6,6 +6,39 @@
             [knossos.core-test :as ct]
             [clojure.pprint :refer [pprint]]))
 
+(deftest timeout-test
+  (testing "will timeout if limit exceeded"
+    (let [model (cas-register 0)
+          history (ct/read-history-2 "data/cas-register/good/memstress3-12.edn")
+          ;; Time limit of 1ms
+          a (analysis model history {:time-limit 1})]
+      (is (= {:valid?   :unknown
+              :cause    :timeout
+              :analyzer :wgl}
+             a))))
+
+  (testing "does not timeout when limit not exceeded"
+    (let [model (register 0)
+          history [(op/invoke 0 :write 1)
+                   (op/ok     0 :write 1)]
+          a (analysis model history {:time-limit 999999999999})]
+      (is (not= {:valid?   :unknown
+                 :cause    :timeout}
+                a))))
+
+  (testing "does not timeout with no time-limit"
+    (let [model (register 0)
+          history [(op/invoke 0 :write 1)
+                   (op/ok     0 :write 1)]
+          a1 (analysis model history)
+          a2 (analysis model history {:time-limit nil})]
+      (is (not= {:valid?   :unknown
+                 :cause    :timeout}
+                a1))
+      (is (not= {:valid?   :unknown
+                 :cause    :timeout}
+                a2)))))
+
 (deftest crash-test
   (let [model (register 0)
         history [(op/invoke 0 :write 1)


### PR DESCRIPTION
The `"will timeout if limit exceeded"` test in `knossos.linear_test` had a habit of completing before the minimum timeout with a few datasets. However it seems to timeout every time with the memstress3-14.edn history. Hoping this remains deterministic, but these new tests could be finicky.

They're pretty safe to ignore in travis though, and adding the `^:perf` metadata will skip them in CI.