### PR TITLE
project: swap to [metametadata/multiset 0.1.1] which has the NPE fix

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -17,7 +17,7 @@
                   :exclusions [org.clojure/clojure]]
                  [org.clojure/tools.logging "0.3.1"]
                  [org.slf4j/slf4j-log4j12 "1.7.21"]
-                 [org.clojars.achim/multiset "0.1.0"]]
+                 [metametadata/multiset "0.1.1"]]
   ; "-verbose:gc" "-XX:+PrintGCDetails"
   :test-selectors {:default (complement :perf)
                    :perf :perf


### PR DESCRIPTION
This is a follow-up to jepsen-io/jepsen#314 and jepsen-io/jepsen#323.

I stumbled on the same NPE when adapting the existing RabbitMQ test to the new Raft-based queue:

```
ERROR [2019-04-15 11:05:14,960] main - jepsen.cli Oh jeez, I'm sorry, Jepsen broke. Here's why:
java.util.concurrent.ExecutionException: java.lang.NullPointerException
	at java.util.concurrent.FutureTask.report(FutureTask.java:122) ~[na:1.8.0_191]
	at java.util.concurrent.FutureTask.get(FutureTask.java:192) ~[na:1.8.0_191]
	at clojure.core$deref_future.invokeStatic(core.clj:2300) ~[clojure-1.10.0.jar:na]
	at clojure.core$future_call$reify__8439.deref(core.clj:6974) ~[clojure-1.10.0.jar:na]
	at clojure.core$deref.invokeStatic(core.clj:2320) ~[clojure-1.10.0.jar:na]
	at clojure.core$deref.invoke(core.clj:2306) ~[clojure-1.10.0.jar:na]
	at clojure.core$map$fn__5851.invoke(core.clj:2753) ~[clojure-1.10.0.jar:na]
	at clojure.lang.LazySeq.sval(LazySeq.java:42) ~[clojure-1.10.0.jar:na]
	at clojure.lang.LazySeq.seq(LazySeq.java:51) ~[clojure-1.10.0.jar:na]
	at clojure.lang.RT.seq(RT.java:531) ~[clojure-1.10.0.jar:na]
	at clojure.core$seq__5387.invokeStatic(core.clj:137) ~[clojure-1.10.0.jar:na]
	at clojure.core$dorun.invokeStatic(core.clj:3133) ~[clojure-1.10.0.jar:na]
	at clojure.core$dorun.invoke(core.clj:3133) ~[clojure-1.10.0.jar:na]
	at jepsen.store$save_2_BANG_.invokeStatic(store.clj:401) ~[jepsen-0.1.13.jar:na]
	at jepsen.store$save_2_BANG_.invoke(store.clj:397) ~[jepsen-0.1.13.jar:na]
	at jepsen.core$analyze_BANG_.invokeStatic(core.clj:450) ~[jepsen-0.1.13.jar:na]
	at jepsen.core$analyze_BANG_.invoke(core.clj:434) ~[jepsen-0.1.13.jar:na]
	at jepsen.core$run_BANG_$fn__5703.invoke(core.clj:564) ~[jepsen-0.1.13.jar:na]
	at jepsen.core$run_BANG_.invokeStatic(core.clj:538) ~[jepsen-0.1.13.jar:na]
	at jepsen.core$run_BANG_.invoke(core.clj:467) ~[jepsen-0.1.13.jar:na]
	at jepsen.cli$single_test_cmd$fn__6411.invoke(cli.clj:362) ~[jepsen-0.1.13.jar:na]
	at jepsen.cli$run_BANG_.invokeStatic(cli.clj:299) [jepsen-0.1.13.jar:na]
	at jepsen.cli$run_BANG_.invoke(cli.clj:229) [jepsen-0.1.13.jar:na]
	at jepsen.rabbitmq$_main.invokeStatic(rabbitmq.clj:246) [na:na]
	at jepsen.rabbitmq$_main.doInvoke(rabbitmq.clj:242) [na:na]
	at clojure.lang.RestFn.invoke(RestFn.java:408) [clojure-1.10.0.jar:na]
	at clojure.lang.Var.invoke(Var.java:384) [clojure-1.10.0.jar:na]
	at user$eval140.invokeStatic(form-init1986127161986909125.clj:1) [na:na]
	at user$eval140.invoke(form-init1986127161986909125.clj:1) [na:na]
	at clojure.lang.Compiler.eval(Compiler.java:7176) [clojure-1.10.0.jar:na]
	at clojure.lang.Compiler.eval(Compiler.java:7166) [clojure-1.10.0.jar:na]
	at clojure.lang.Compiler.load(Compiler.java:7635) [clojure-1.10.0.jar:na]
	at clojure.lang.Compiler.loadFile(Compiler.java:7573) [clojure-1.10.0.jar:na]
	at clojure.main$load_script.invokeStatic(main.clj:452) [clojure-1.10.0.jar:na]
	at clojure.main$init_opt.invokeStatic(main.clj:454) [clojure-1.10.0.jar:na]
	at clojure.main$init_opt.invoke(main.clj:454) [clojure-1.10.0.jar:na]
	at clojure.main$initialize.invokeStatic(main.clj:485) [clojure-1.10.0.jar:na]
	at clojure.main$null_opt.invokeStatic(main.clj:519) [clojure-1.10.0.jar:na]
	at clojure.main$null_opt.invoke(main.clj:516) [clojure-1.10.0.jar:na]
	at clojure.main$main.invokeStatic(main.clj:598) [clojure-1.10.0.jar:na]
	at clojure.main$main.doInvoke(main.clj:561) [clojure-1.10.0.jar:na]
	at clojure.lang.RestFn.applyTo(RestFn.java:137) [clojure-1.10.0.jar:na]
	at clojure.lang.Var.applyTo(Var.java:705) [clojure-1.10.0.jar:na]
	at clojure.main.main(main.java:37) [clojure-1.10.0.jar:na]
Caused by: java.lang.NullPointerException: null
	at multiset.core.MultiSet.iterator(core.clj:73) ~[knossos-0.3.4.jar:na]
	at clojure.lang.RT.iter(RT.java:569) ~[clojure-1.10.0.jar:na]
	at clojure.core$sequence.invokeStatic(core.clj:2663) ~[clojure-1.10.0.jar:na]
	at clojure.core$sequence.invoke(core.clj:2647) ~[clojure-1.10.0.jar:na]
	at fipp.edn$pretty_coll.invokeStatic(edn.cljc:15) ~[jepsen-0.1.13.jar:na]
	at fipp.edn$pretty_coll.invoke(edn.cljc:8) ~[jepsen-0.1.13.jar:na]
	at fipp.edn.EdnPrinter.visit_set(edn.cljc:65) ~[jepsen-0.1.13.jar:na]
	at fipp.visit$visit_STAR_.invokeStatic(visit.cljc:48) ~[jepsen-0.1.13.jar:na]
	at fipp.visit$visit_STAR_.invoke(visit.cljc:32) ~[jepsen-0.1.13.jar:na]
	at fipp.visit$visit.invokeStatic(visit.cljc:61) ~[jepsen-0.1.13.jar:na]
	at fipp.visit$visit.invoke(visit.cljc:58) ~[jepsen-0.1.13.jar:na]
	at fipp.edn.EdnPrinter$fn__2010.invoke(edn.cljc:62) ~[jepsen-0.1.13.jar:na]
	at fipp.edn$pretty_coll$fn__1989.invoke(edn.cljc:12) ~[jepsen-0.1.13.jar:na]
	at clojure.core$map$fn__5847$fn__5848.invoke(core.clj:2742) ~[clojure-1.10.0.jar:na]
	at clojure.lang.TransformerIterator.step(TransformerIterator.java:79) ~[clojure-1.10.0.jar:na]
	at clojure.lang.TransformerIterator.hasNext(TransformerIterator.java:97) ~[clojure-1.10.0.jar:na]
	at clojure.lang.RT$4.invoke(RT.java:518) ~[clojure-1.10.0.jar:na]
	at clojure.lang.LazySeq.sval(LazySeq.java:42) ~[clojure-1.10.0.jar:na]
	at clojure.lang.LazySeq.seq(LazySeq.java:51) ~[clojure-1.10.0.jar:na]
	at clojure.lang.RT.seq(RT.java:531) ~[clojure-1.10.0.jar:na]
	at clojure.core$seq__5387.invokeStatic(core.clj:137) ~[clojure-1.10.0.jar:na]
	at clojure.core$map$fn__5851.invoke(core.clj:2746) ~[clojure-1.10.0.jar:na]
	at clojure.lang.LazySeq.sval(LazySeq.java:42) ~[clojure-1.10.0.jar:na]
	at clojure.lang.LazySeq.seq(LazySeq.java:51) ~[clojure-1.10.0.jar:na]
	at clojure.lang.RT.seq(RT.java:531) ~[clojure-1.10.0.jar:na]
	at clojure.core$seq__5387.invokeStatic(core.clj:137) ~[clojure-1.10.0.jar:na]
	at clojure.core$apply.invokeStatic(core.clj:660) ~[clojure-1.10.0.jar:na]
	at clojure.core$mapcat.invokeStatic(core.clj:2783) ~[clojure-1.10.0.jar:na]
	at clojure.core$mapcat.doInvoke(core.clj:2783) ~[clojure-1.10.0.jar:na]
	at clojure.lang.RestFn.invoke(RestFn.java:423) [clojure-1.10.0.jar:na]
	at fipp.engine$serialize.invokeStatic(engine.cljc:15) ~[jepsen-0.1.13.jar:na]
	at fipp.engine$serialize.invoke(engine.cljc:12) ~[jepsen-0.1.13.jar:na]
	at clojure.core$map$fn__5851.invoke(core.clj:2753) ~[clojure-1.10.0.jar:na]
	at clojure.lang.LazySeq.sval(LazySeq.java:42) ~[clojure-1.10.0.jar:na]
	at clojure.lang.LazySeq.seq(LazySeq.java:51) ~[clojure-1.10.0.jar:na]
	at clojure.lang.RT.seq(RT.java:531) ~[clojure-1.10.0.jar:na]
	at clojure.core$seq__5387.invokeStatic(core.clj:137) ~[clojure-1.10.0.jar:na]
	at clojure.core$apply.invokeStatic(core.clj:660) ~[clojure-1.10.0.jar:na]
	at clojure.core$mapcat.invokeStatic(core.clj:2783) ~[clojure-1.10.0.jar:na]
	at clojure.core$mapcat.doInvoke(core.clj:2783) ~[clojure-1.10.0.jar:na]
	at clojure.lang.RestFn.invoke(RestFn.java:423) [clojure-1.10.0.jar:na]
	at fipp.engine$serialize.invokeStatic(engine.cljc:15) ~[jepsen-0.1.13.jar:na]
	at fipp.engine$serialize.invoke(engine.cljc:12) ~[jepsen-0.1.13.jar:na]
	at fipp.engine$fn__1949.invokeStatic(engine.cljc:63) ~[jepsen-0.1.13.jar:na]
	at fipp.engine$fn__1949.invoke(engine.cljc:58) ~[jepsen-0.1.13.jar:na]
	at clojure.lang.MultiFn.invoke(MultiFn.java:229) ~[clojure-1.10.0.jar:na]
	at fipp.engine$serialize.invokeStatic(engine.cljc:18) ~[jepsen-0.1.13.jar:na]
	at fipp.engine$serialize.invoke(engine.cljc:12) ~[jepsen-0.1.13.jar:na]
	at clojure.core$map$fn__5851.invoke(core.clj:2753) ~[clojure-1.10.0.jar:na]
	at clojure.lang.LazySeq.sval(LazySeq.java:42) ~[clojure-1.10.0.jar:na]
	at clojure.lang.LazySeq.seq(LazySeq.java:51) ~[clojure-1.10.0.jar:na]
	at clojure.lang.RT.seq(RT.java:531) ~[clojure-1.10.0.jar:na]
	at clojure.core$seq__5387.invokeStatic(core.clj:137) ~[clojure-1.10.0.jar:na]
	at clojure.core$apply.invokeStatic(core.clj:660) ~[clojure-1.10.0.jar:na]
	at clojure.core$mapcat.invokeStatic(core.clj:2783) ~[clojure-1.10.0.jar:na]
	at clojure.core$mapcat.doInvoke(core.clj:2783) ~[clojure-1.10.0.jar:na]
	at clojure.lang.RestFn.invoke(RestFn.java:423) [clojure-1.10.0.jar:na]
	at fipp.engine$serialize.invokeStatic(engine.cljc:15) ~[jepsen-0.1.13.jar:na]
	at fipp.engine$serialize.invoke(engine.cljc:12) ~[jepsen-0.1.13.jar:na]
	at fipp.engine$fn__1934.invokeStatic(engine.cljc:48) ~[jepsen-0.1.13.jar:na]
	at fipp.engine$fn__1934.invoke(engine.cljc:47) ~[jepsen-0.1.13.jar:na]
	at clojure.lang.MultiFn.invoke(MultiFn.java:229) ~[clojure-1.10.0.jar:na]
	at fipp.engine$serialize.invokeStatic(engine.cljc:18) ~[jepsen-0.1.13.jar:na]
	at fipp.engine$serialize.invoke(engine.cljc:12) ~[jepsen-0.1.13.jar:na]
	at fipp.engine$pprint_document.invokeStatic(engine.cljc:236) ~[jepsen-0.1.13.jar:na]
	at fipp.engine$pprint_document.invoke(engine.cljc:234) ~[jepsen-0.1.13.jar:na]
	at fipp.edn$pprint.invokeStatic(edn.cljc:100) ~[jepsen-0.1.13.jar:na]
	at fipp.edn$pprint.invoke(edn.cljc:91) ~[jepsen-0.1.13.jar:na]
	at fipp.edn$pprint.invokeStatic(edn.cljc:92) ~[jepsen-0.1.13.jar:na]
	at fipp.edn$pprint.invoke(edn.cljc:91) ~[jepsen-0.1.13.jar:na]
	at jepsen.store$write_results_BANG_.invokeStatic(store.clj:358) ~[jepsen-0.1.13.jar:na]
	at jepsen.store$write_results_BANG_.invoke(store.clj:340) ~[jepsen-0.1.13.jar:na]
	at jepsen.store$save_2_BANG_$fn__3900.invoke(store.clj:401) ~[jepsen-0.1.13.jar:na]
	at clojure.core$binding_conveyor_fn$fn__5739.invoke(core.clj:2030) ~[clojure-1.10.0.jar:na]
	at clojure.lang.AFn.call(AFn.java:18) ~[clojure-1.10.0.jar:na]
	at java.util.concurrent.FutureTask.run(FutureTask.java:266) ~[na:1.8.0_191]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) ~[na:1.8.0_191]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) ~[na:1.8.0_191]
	at java.lang.Thread.run(Thread.java:748) ~[na:1.8.0_191]
```

Fixing the library in the Jepsen does not seem enough, the fix should also be in Knossos (which is more consistent anyway). Doing so fixed the problem in my case.