### PR TITLE
filter nil ops out of the analysis results

### DIFF
--- a/data/cas-register/bad/immediate-failure.edn
+++ b/data/cas-register/bad/immediate-failure.edn
@@ -1,0 +1,4 @@
+[{:type :invoke, :process 1, :f :read, :value nil}
+{:type :invoke, :process 101, :f :write, :value 3}
+{:type :fail, :process 101, :f :write, :value 3, :error [:temporarily-unavailable nil]}
+{:type :ok, :process 1, :f :read, :value 3}]

--- a/src/knossos/analysis.clj
+++ b/src/knossos/analysis.clj
@@ -64,5 +64,7 @@
          (r/map #(concat % (list final)))
          ; And extend the prefix along those paths
          (r/map (partial extend-path prefix))
+         ; Remove any nil ops, which can come from an empty prefix
+         (r/map (r/filter :op))
          ; Computing a set
          (foldset))))

--- a/test/knossos/core_test.clj
+++ b/test/knossos/core_test.clj
@@ -68,7 +68,7 @@
     (dothreads [process process-count]
                (try
                  (dotimes [i action-count]
-                   (Thread/sleep (rand-int 5))
+                   (Thread/sleep (long (rand-int 5)))
                    (when (< (rand) crash-factor) (assert false))
 
                    (let [value (rand-int 10)]

--- a/test/knossos/linear_test.clj
+++ b/test/knossos/linear_test.clj
@@ -80,8 +80,7 @@
     (is (= false (:valid? a)))
     (is (= {:process 0, :type :ok, :f :read, :value 1 :index 1}
            (:op a)))
-    (is (= #{[{:op nil, :model model}
-              {:op {:process 0 :type :ok :f :read :value 1 :index 1},
+    (is (= #{[{:op {:process 0 :type :ok :f :read :value 1 :index 1},
                :model (inconsistent "0≠1")}]},
            (:final-paths a)))
     (is (not (:last-op a)))
@@ -110,8 +109,7 @@
                       :value    1
                       :index    0}]}]
            (:configs a)))
-    (is (= #{[{:model model :op nil}
-              {:model (inconsistent "0≠1")
+    (is (= #{[{:model (inconsistent "0≠1")
                :op {:process 0 :type :ok :f :read :value 1 :index 1}}]}
          (:final-paths a)))))
 
@@ -176,6 +174,19 @@
     (is (= #{(multi-register {:x 2 :y 2})
              (multi-register {:x 2 :y 0})}
            (set (map :model (:configs a)))))))
+
+(deftest immediate-failure-test
+  (let [a (analysis (cas-register 0)
+                    (ct/read-history-2 "data/cas-register/bad/immediate-failure.edn"))]
+    (is (= false (:valid? a)))
+    (is (= {:process 1, :type :ok, :f :read, :value 3 :index 3}
+           (:op a)))
+    (is (= #{[
+              {:op {:process 1 :type :ok :f :read :value 3 :index 3},
+               :model (inconsistent "can't read 3 from register 0")}]},
+           (:final-paths a)))
+    (is (not (:last-op a)))
+    (is (not (:previous-ok a)))))
 
 (deftest ^:perf volatile-linearizable-test
   (dotimes [i 10]

--- a/test/knossos/report_test.clj
+++ b/test/knossos/report_test.clj
@@ -36,6 +36,10 @@
   (report! linear/analysis (cas-register nil)
            "data/cas-register/bad/cas-failure.edn"))
 
+(deftest cas-immediate-failure
+  (report! linear/analysis (cas-register 0)
+           "data/cas-register/bad/immediate-failure.edn"))
+
 (deftest bad-analysis-test-wgl
   (report! wgl/analysis (register 0)
            "data/cas-register/bad/bad-analysis.edn"))
@@ -47,6 +51,10 @@
 (deftest cas-failure-wgl
   (report! wgl/analysis (cas-register nil)
            "data/cas-register/bad/cas-failure.edn"))
+
+(deftest cas-immediate-failure-wgl
+  (report! wgl/analysis (cas-register 0)
+           "data/cas-register/bad/immediate-failure.edn"))
 
 (deftest etcd-mutex
   (report! wgl/analysis (mutex) "data/mutex/bad/etcd.edn"))

--- a/test/knossos/wgl_test.clj
+++ b/test/knossos/wgl_test.clj
@@ -76,9 +76,7 @@
             :valid?      false
             :op          {:process 0 :type :ok :f :read :value 1 :index 1}
             :previous-ok nil
-            :final-paths #{[{:model model
-                             :op nil}
-                            {:model (inconsistent "0≠1")
+            :final-paths #{[{:model (inconsistent "0≠1")
                              :op {:f :read, :process 0 :type :ok :value 1 :index 1}}]}}
            a))))
 
@@ -146,6 +144,19 @@
     (is (= false (:valid? a)))
     (is (= {:f :read :process 70 :type :ok :value 0 :index 491}
            (:op a)))))
+
+(deftest immediate-failure-test
+  (let [a (analysis (cas-register 0)
+                    (ct/read-history-2 "data/cas-register/bad/immediate-failure.edn"))]
+    (is (= false (:valid? a)))
+    (is (= {:process 1, :type :ok, :f :read, :value 3 :index 3}
+           (:op a)))
+    (is (= #{[
+              {:op {:process 1 :type :ok :f :read :value 3 :index 3},
+               :model (inconsistent "can't read 3 from register 0")}]},
+           (:final-paths a)))
+    (is (not (:last-op a)))
+    (is (not (:previous-ok a)))))
 
 (deftest volatile-linearizable-test
   (dotimes [i 10]


### PR DESCRIPTION
This is in response to [this Maelstrom issue](https://github.com/jepsen-io/maelstrom/issues/92), and fixes #36 in this repo as well.

I am very open to any feedback/suggestions, this is my first foray into Clojure (and Knossos as well)

Filtering out the nulls after the fact feels slightly bad, vs avoiding them in the first place. But the analysis code relies on having that first op in the prefix, in order to pass in the initial model. So I think overall this is probably a good targeted solution?